### PR TITLE
vagrant testing changes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,18 @@ Created Template: 95f948b6-cf87-4d64-bb56-1f5087ae6588
 Created Workflow: 508569a3-0275-4f50-b957-51d4de6c21ae
 ```
 
-## Notes
+You can also execute tink-cli without `create_tink_workflow.sh` script by individually inserting the template and hardware. You can modifiy `hw_data_hardcoded.json` as per you requirement and then create the workflow.
+```
+$ docker exec -i deploy_tink-cli_1 tink template create --name bullseye < ./bullseye.yml
+Created Template:  7e8b59b5-4ce2-448a-a4a8-1aa5db7dd519
+$ docker exec -i deploy_tink_cli_1 tink hardware push < ./hw_data_hardcoded.json
+$ docker exec -i deploy_tink-cli_1 tink workflow create \
+    -t 7e8b59b5-4ce2-448a-a4a8-1aa5db7dd519  \
+    -r '{"device_1":"08:00:27:00:00:01"}'
+```
 
+## Notes
+* Vagrant users: To boot to Debian after workflow is completed, reboot the machine, go to the boot menu and select Debian boot loader.
 * All workflow actions run as `--privileged` Docker containers.
 
 ## Author

--- a/debian/hw_data_hardcoded.json
+++ b/debian/hw_data_hardcoded.json
@@ -1,0 +1,196 @@
+{
+  "id": "0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94",
+  "metadata": {
+    "cloud_cfg": {
+      "apt_preserve_sources_list": "true",
+      "cloud_config_modules": [
+        "emit_upstart",
+        "ssh-import-id",
+        "locale",
+        "set-passwords",
+        "grub-dpkg",
+        "apt-pipelining",
+        "apt-configure",
+        "ntp",
+        "timezone",
+        "disable-ec2-metadata",
+        "runcmd",
+        "byobu"
+      ],
+      "cloud_final_modules": [
+        "package-update-upgrade-install",
+        "fan",
+        "puppet",
+        "chef",
+        "salt-minion",
+        "mcollective",
+        "rightscale_userdata",
+        "scripts-vendor",
+        "scripts-per-once",
+        "scripts-per-boot",
+        "scripts-per-instance",
+        "scripts-user",
+        "ssh-authkey-fingerprints",
+        "keys-to-console",
+        "phone-home",
+        "final-message",
+        "power-state-change"
+      ],
+      "cloud_init_modules": [
+        "migrator",
+        "seed_random",
+        "bootcmd",
+        "write-files",
+        "growpart",
+        "resizefs",
+        "disk_setup",
+        "mounts",
+        "set_hostname",
+        "update_hostname",
+        "update_etc_hosts",
+        "ca-certs",
+        "rsyslog",
+        "users-groups",
+        "ssh"
+      ],
+      "disable_root": "true",
+      "preserve_hostname": "false",
+      "system_info": {
+        "default_user": {
+          "gecos": "Debian",
+          "groups": [
+            "admin",
+            "users",
+            "sudo"
+          ],
+          "lock_passwd": "true",
+          "name": "debian",
+          "passwd": "test1234",
+          "shell": "/bin/bash",
+          "ssh_authorized_keys": [
+            "ssh-rsa"
+          ],
+          "ssh_pwauth": "true",
+          "sudo": [
+            "ALL=(ALL) NOPASSWD:ALL"
+          ]
+        },
+        "distro": "debian",
+        "package_mirrors": [
+          {
+            "arches": [
+              "default"
+            ],
+            "failsafe": {
+              "primary": "http://deb.debian.org/debian",
+              "security": "http://security.debian.org/"
+            }
+          }
+        ],
+        "paths": {
+          "cloud_dir": "/var/lib/cloud/",
+          "templates_dir": "/etc/cloud/templates/",
+          "upstart_dir": "/etc/init/"
+        },
+        "ssh_svcname": "ssh"
+      },
+      "users": [
+        "default"
+      ]
+    },
+    "facility": {
+      "facility_code": "onprem",
+      "plan_slug": "c2.medium.x86",
+      "plan_version_slug": ""
+    },
+    "instance": {
+      "crypted_root_password": "test1234"
+      "hostname": "server0001",
+      "operating_system_version": {
+        "distro": "debian",
+        "version": "11",
+        "os_slug": "debian_11",
+        "os_codename": "bullseye"
+      },
+      "storage": {
+        "disks": [
+          {
+            "device": "/dev/sda",
+            "partitions": [
+              {
+                "label": "BIOS",
+                "number": 1,
+                "size": 4096
+              },
+              {
+                "label": "SWAP",
+                "number": 2,
+                "size": 3993600
+              },
+              {
+                "label": "ROOT",
+                "number": 3,
+                "size": 0
+              }
+            ],
+            "wipe_table": true
+          }
+        ],
+        "filesystems": [
+          {
+            "mount": {
+              "create": {
+                "options": ["-L", "ROOT"]
+              },
+              "device": "/dev/sda3",
+              "format": "ext4",
+              "point": "/"
+            }
+          },
+          {
+            "mount": {
+              "create": {
+                "options": ["-L", "SWAP"]
+              },
+              "device": "/dev/sda2",
+              "format": "swap",
+              "point": "none"
+            }
+          }
+        ]
+      }
+    },
+    "manufacturer": {
+      "id": "",
+      "slug": ""
+    },
+    "state": "provisioning"
+  },
+  "network": {
+    "interfaces": [
+      {
+        "dhcp": {
+          "arch": "x86_64",
+          "hostname": "server0001",
+          "ip": {
+            "address": "192.168.1.5",
+            "gateway": "192.168.1.1",
+            "netmask": "255.255.255.248"
+          },
+          "lease_time": 86400,
+          "mac": "08:00:27:00:00:01",
+          "uefi": false
+        },
+        "netboot": {
+          "allow_pxe": true,
+          "allow_workflow": true,
+          "osie": {
+            "base_url": "",
+            "initrd": "",
+            "kernel": "vmlinuz-x86_64"
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Changes with reference to:
- Testing done on Vagrant. Updated README file as per testing. 
- Hardcoded hardware file to let users manually insert hardware. Less dependency on `create_tink_workflow.sh` script.